### PR TITLE
fix system-config-firewall package removal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -330,7 +330,9 @@ korora_packages_common:
     - abrt
     - ntp
     - system-config-date
-    - system-config-firewall*
+    - system-config-firewall
+    - system-config-firewall-base
+    - system-config-firewall-tui
     - system-config-keyboard
     - system-config-language
     - system-config-services


### PR DESCRIPTION
Wildcard is not supported for a package removal, this caused packages
task to fail. This patch replaces the wildcard with the actual packages
names.