### PR TITLE
Set pipefail on shell task

### DIFF
--- a/tasks/lookandfeel-gnome.yml
+++ b/tasks/lookandfeel-gnome.yml
@@ -154,9 +154,11 @@
 
 ## Set GNOME terminal config
 - name: Get terminal UUID
-  shell: gsettings get org.gnome.Terminal.ProfilesList default | tr -d \'
+  shell: set -o pipefail && gsettings get org.gnome.Terminal.ProfilesList default | tr -d \'
   register: gnome_terminal_uuid
   changed_when: false
+  args:
+    executable: /usr/bin/bash
   become: true
 
 - name: Ensure directory exists for terminal profile


### PR DESCRIPTION
Set pipefail when running a shell command with a pipe. This makes it
more robust and removes Ansible lint warning.