### PR TITLE
updates for fedora 33

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,8 +87,8 @@ korora_selinux_state: enforcing
 korora_sysrq_value: "1"
 
 ## Repos
-korora_rpmfusion_free_key: https://rpmfusion.org/keys?action=AttachFile&do=get&target=RPM-GPG-KEY-rpmfusion-free-fedora-{{ ansible_distribution_major_version }}
-korora_rpmfusion_nonfree_key: https://rpmfusion.org/keys?action=AttachFile&do=get&target=RPM-GPG-KEY-rpmfusion-nonfree-fedora-{{ ansible_distribution_major_version }}
+korora_rpmfusion_free_key: https://rpmfusion.org/keys?action=AttachFile&do=get&target=RPM-GPG-KEY-rpmfusion-free-fedora-{{ ansible_distribution_major_version if ansible_distribution_major_version <= "32" else "2020" }}
+korora_rpmfusion_nonfree_key: https://rpmfusion.org/keys?action=AttachFile&do=get&target=RPM-GPG-KEY-rpmfusion-nonfree-fedora-{{ ansible_distribution_major_version if ansible_distribution_major_version <= "32" else "2020" }}
 korora_rpmfusion_free_rpm: https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_major_version }}.noarch.rpm
 korora_rpmfusion_nonfree_rpm: https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ ansible_distribution_major_version }}.noarch.rpm
 korora_flatpak_repo: https://dl.flathub.org/repo/flathub.flatpakrepo
@@ -298,7 +298,6 @@ korora_packages_common:
     - mlocate
     - ntfsprogs
     - powertop
-    - pybluez
     - redhat-lsb-core
     - vim
 

--- a/tasks/lookandfeel-gnome.yml
+++ b/tasks/lookandfeel-gnome.yml
@@ -1,4 +1,14 @@
 ---
+- name: "Install critical path for {{ korora_desktop }}"
+  dnf:
+    name: "@critical-path-gnome"
+    state: present
+  register: dnf_gnome_result
+  retries: "{{ korora_task_retries }}"
+  delay: "{{ korora_task_delay }}"
+  until: dnf_gnome_result is succeeded
+  become: true
+
 - name: "Install look and feel packages for {{ korora_desktop }}"
   dnf:
     name: "{{ korora_packages_lookandfeel_gnome['install'] }}"

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -39,6 +39,7 @@
   dnf:
     name: "{{ korora_packages_common['install'] }}"
     state: present
+    skip_broken: true
   register: dnf_install_result
   retries: "{{ korora_task_retries }}"
   delay: "{{ korora_task_delay }}"
@@ -50,6 +51,7 @@
     name: "{{ korora_packages_custom['remove'] }}"
     state: absent
     autoremove: no
+    skip_broken: true
   register: dnf_remove_custom_result
   when: korora_packages_custom['remove'] is defined and korora_packages_custom['remove']
   retries: "{{ korora_task_retries }}"

--- a/tasks/repos.yml
+++ b/tasks/repos.yml
@@ -16,6 +16,7 @@
     section: google-chrome
     option: enabled
     value: "1"
+    mode: 0644
   become: true
 
 - name: Enable RPMFusion NVIDIA repo
@@ -24,6 +25,7 @@
     section: rpmfusion-nonfree-nvidia-driver
     option: enabled
     value: "1"
+    mode: 0644
   become: true
 
 - name: Enable RPMFusion Steam repo
@@ -32,6 +34,7 @@
     section: rpmfusion-nonfree-steam
     option: enabled
     value: "1"
+    mode: 0644
   become: true
 
 # Import RPMFusion GPG keys
@@ -43,6 +46,7 @@
   retries: "{{ korora_task_retries }}"
   delay: "{{ korora_task_delay }}"
   until: rpm_key_rpmfusion_free_result is succeeded
+  failed_when: false
   become: true
 
 - name: Import RPMFusion Nonfree GPG key
@@ -53,6 +57,7 @@
   retries: "{{ korora_task_retries }}"
   delay: "{{ korora_task_delay }}"
   until: rpm_key_rpmfusion_nonfree_result is succeeded
+  failed_when: false
   become: true
 
 # Enable RPMFusion repos

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure systemd graphical target is set
+  command: systemctl set-default graphical.target
+  register: result_target
+  changed_when: false
+  become: true
+
 - name: Ensure man-db and mlocate are installed to update their databases
   dnf:
     name: man-db, mlocate


### PR DESCRIPTION
Ensure we can get to a graphical desktop from base cloud image, which
includes installing critical-gnome package group and enabling graphical
target.